### PR TITLE
Hivelord Cores do not replace mechanical limbs

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -289,7 +289,7 @@
 			else
 				to_chat(user, "<span class='notice'>You chomp into [src], barely managing to hold it down, but feel amazingly refreshed in mere moments.</span>")
 			playsound(src.loc,'sound/items/eatfood.ogg', rand(10,50), 1)
-			H.revive()
+			H.rejuvenate()
 			qdel(src)
 	..()
 


### PR DESCRIPTION
Fixes #1967.

:cl:
bugfix: Hivelord cores no longer replace mechanical limbs with organic ones
/:cl:
