### PR TITLE
Removes needless fax guides

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -47,7 +47,6 @@
 
 	New()
 		..()
-		new /obj/item/weapon/book/manual/faxes(src)
 		new /obj/item/clothing/glasses/sunglasses(src)
 		new /obj/item/clothing/head/hopcap(src)
 		new /obj/item/weapon/cartridge/hop(src)
@@ -103,7 +102,6 @@
 			new /obj/item/weapon/storage/backpack/security(src)
 		else
 			new /obj/item/weapon/storage/backpack/satchel_sec(src)
-		new /obj/item/weapon/book/manual/faxes(src)
 		new /obj/item/weapon/cartridge/hos(src)
 		new /obj/item/device/radio/headset/heads/hos/alt(src)
 		new /obj/item/clothing/under/rank/head_of_security(src)


### PR DESCRIPTION
Fixes #5700

- Due to budget cuts, the Head of Personnel and Head of Security will no longer be provided with a Fax Guide

:cl:
tweak: HoP and HoS no longer have Fax Guides in their lockers
/:cl: